### PR TITLE
Fix quoting in command line saved to run script in profile.

### DIFF
--- a/oc-cluster
+++ b/oc-cluster
@@ -38,10 +38,10 @@ function up {
     mkdir -p $OPENSHIFT_HOST_DATA_DIR
     mkdir -p $OPENSHIFT_HOST_VOLUMES_DIR
 
-    echo "oc cluster up --public-hostname $OC_CLUSTER_PUBLIC_HOSTNAME \
-                --host-data-dir $OPENSHIFT_HOST_DATA_DIR \
-                --host-config-dir $OPENSHIFT_HOST_CONFIG_DIR \
-                --routing-suffix "$OC_CLUSTER_ROUTING_SUFFIX" \
+    echo "oc cluster up --public-hostname '$OC_CLUSTER_PUBLIC_HOSTNAME' \
+                --host-data-dir '$OPENSHIFT_HOST_DATA_DIR' \
+                --host-config-dir '$OPENSHIFT_HOST_CONFIG_DIR' \
+                --routing-suffix '$OC_CLUSTER_ROUTING_SUFFIX' \
                 --use-existing-config \
                 $@" > $OPENSHIFT_HOME_DIR/profiles/$_profile/run
 


### PR DESCRIPTION
Addresses this issue when starting up a profile which had already been shutdown.

```
$ ../oc-cluster-wrapper/oc-cluster up
Using default profile
[INFO] Running a previously created cluster
oc cluster up --public-hostname 127.0.0.1 --host-data-dir 
/Users/stefanopicozzi/.oc/profiles/default/data --host-config-dir 
/Users/stefanopicozzi/.oc/profiles/default/config --routing-suffix 
--use-existing-config
-- Checking OpenShift client ... OK
-- Checking Docker client ... OK
-- Checking Docker version ... OK
-- Checking for existing OpenShift container ...
    Deleted existing OpenShift container
-- Checking for openshift/origin:v1.3.0 image ... OK
-- Checking Docker daemon configuration ... OK
-- Checking for available ports ... OK
-- Checking type of volume mount ...
    Using Docker shared volumes for OpenShift volumes
-- Creating host directories ... OK
-- Finding server IP ...
    Using public hostname IP 127.0.0.1 as the host IP
    Using 127.0.0.1 as the server IP
-- Starting OpenShift container ...
    Creating initial OpenShift configuration
    Starting OpenShift using container 'origin'
FAIL
    Error: could not start OpenShift container "origin"
    Details:
      Last 10 lines of "origin" container log:
      W1007 02:03:33.494632    7642 start_master.go:272] Warning: 
assetConfig.loggingPublicURL: Invalid value: "": required to view 
aggregated container logs in the console, master start will continue.
      W1007 02:03:33.494765    7642 start_master.go:272] Warning: 
assetConfig.metricsPublicURL: Invalid value: "": required to view 
cluster metrics in the console, master start will continue.
      error: Invalid MasterConfig 
/var/lib/origin/openshift.local.config/master/master-config.yaml
        routingConfig.subdomain: Invalid value: "--use-existing-config": 
must be a valid subdomain

```

Problem was that wrong quote was used and so quotes went missing from command line saved to the run file, which caused problems when argument was an empty string.

To fix up profile if already encountered issue and have fixed wrapper script, remove the ``run`` script file from the profile directory. Eg: ``~/.oc/profiles/default/run``. It will be recreated the next time.

