### PR TITLE
fixes #14 allow second run of cluster up to bring in aditional argumetnts, will not be persistend but run for this one run of the profile

### DIFF
--- a/oc-cluster
+++ b/oc-cluster
@@ -37,7 +37,7 @@ function up {
                 --host-config-dir '$OPENSHIFT_HOST_CONFIG_DIR' \
                 --routing-suffix '$OC_CLUSTER_ROUTING_SUFFIX' \
                 --use-existing-config \
-                $@" > $OPENSHIFT_HOME_DIR/profiles/$_profile/run
+                $@ \$@" > $OPENSHIFT_HOME_DIR/profiles/$_profile/run
 
     echo "$(<$OPENSHIFT_HOME_DIR/profiles/$_profile/run)"
 
@@ -65,7 +65,7 @@ function up {
     echo "[INFO] Running a previously created cluster"
     # Just start the cluster
     echo "$(<$OPENSHIFT_HOME_DIR/profiles/$_profile/run)"
-    . $OPENSHIFT_HOME_DIR/profiles/$_profile/run "$@"
+    . $OPENSHIFT_HOME_DIR/profiles/$_profile/run
     status &> /dev/null || error_exit "[ERROR] Cluster has not started correctly. Profile configuration will be preserved"
     # Create the profile markfile
     echo "${_profile}" > $OPENSHIFT_HOME_DIR/active_profile


### PR DESCRIPTION
This simple fix will solve solution 2 in issue #14. 

If we want to modify the run script so that the third run of the profile includes the additional argument then more work is needed. 

Proabably just including the value of $@ in the run file or something. 
