### PR TITLE
Preserve routing suffix on Linux

### DIFF
--- a/oc-cluster
+++ b/oc-cluster
@@ -48,7 +48,7 @@ if [[ "$__PLATFORM" == "linux" ]]; then
   __DOCKER0_IP=$(which-ip)
   echo "Using Docker0 ($__DOCKER0_IP) ip as external cluster and router address"
   OC_CLUSTER_PUBLIC_HOSTNAME=${OC_CLUSTER_PUBLIC_HOSTNAME:-${__DOCKER0_IP}}
-  OC_CLUSTER_ROUTING_SUFFIX=apps.${OC_CLUSTER_PUBLIC_HOSTNAME:-${__DOCKER0_IP}}.nip.io
+  OC_CLUSTER_ROUTING_SUFFIX=${OC_CLUSTER_ROUTING_SUFFIX:-apps.${OC_CLUSTER_PUBLIC_HOSTNAME:-${__DOCKER0_IP}}.nip.io}
   EXTRA_OPTS="--forward-ports=false"
 fi
 


### PR DESCRIPTION
Do not overwrite OC_CLUSTER_ROUTING_SUFFIX if I already set it in my environment