### PR TITLE
added tags.global.plugin

### DIFF
--- a/plugins.d/tag.global.plugin
+++ b/plugins.d/tag.global.plugin
@@ -2,12 +2,13 @@
 
 function tag.help {
    # Select either of the two or both, depending on the functionality provided by the plugin
-   echo "  oc-cluster show-tags <ImageStreamName>"
-   echo "  oc-cluster tag-latest <ImageStreamName> <tag-name> - tags 'latest' ImageStream to <tag-name>"
-   echo "  oc-cluster tag-to-target <ImageStreamName> <source-tag> <target-project> <target-tag>"
-   echo "      Assumes that <source-tag> is something like 'RELEASE_1_1' and <target-tag> is 'latest'"
-   echo "      It first 'copies' the 'RELEASE_1_1' into <target-project> and call it 'latest'"
-   echo "      and then tags <target-project>:latest to 'RELEASE_1_1'"
+   echo "  oc-cluster show-tags <app-name> - Shows all Tags of <app-name> in current project"
+   echo "  oc-cluster tag-latest <app-name> <tag-name> - tags 'latest' <app-name> ImageStream to <tag-name> in current project"
+   echo "  oc-cluster tag-to-target <app-name> <source-tag> <target-project> <target-tag>"
+   echo "             Assumes that <source-tag> is something like 'RELEASE_1_1' and <target-tag> is 'latest'"
+   echo "             It first 'copies' the 'RELEASE_1_1' tagged <app-name> from current project into "
+   echo "             <target-project> and calls it 'latest' and then tags <target-project>:latest"
+   echo "             to 'RELEASE_1_1'"
 }
 
 #
@@ -18,7 +19,8 @@ function tag.help {
 #  $4 target-tag - the name of the target tag in target-project
 #
 function tag-to-target {
-	[ $# -lt 4 ] && echo "ImageStream Name is required." && exit 1
+	[ "$1" == "-h" ] || [ "$1" == "--help" ] && tag.help && return 0
+	[ $# -lt 4 ] && echo "ERROR: All parameters are required!" && tag.help && return 1
 	local IMAGE_STREAM=$1
 	local SOURCE_TAG=$2
 	local TARGET_PROJECT=$3
@@ -32,12 +34,10 @@ function tag-to-target {
 	
 	echo "Tagging '$SOURCE_TAG' image stream '$IMAGE_STREAM' from '$SOURCE_PROJECT' to target project '$TARGET_PROJECT' with tag '$TARGET_TAG'..."
 		
-	oc tag $SOURCE_PROJECT/$IMAGE_STREAM:$SOURCE_TAG $TARGET_PROJECT/$IMAGE_STREAM:$TARGET_TAG
-	oc tag $TARGET_PROJECT/$IMAGE_STREAM:$TARGET_TAG $TARGET_PROJECT/$IMAGE_STREAM:$SOURCE_TAG
+	oc tag $SOURCE_PROJECT/$IMAGE_STREAM:$SOURCE_TAG $TARGET_PROJECT/$IMAGE_STREAM:$TARGET_TAG --as=system:admin
+	oc tag $TARGET_PROJECT/$IMAGE_STREAM:$TARGET_TAG $TARGET_PROJECT/$IMAGE_STREAM:$SOURCE_TAG --as=system:admin
 	
-	oc project $TARGET_PROJECT
-	oc label is $IMAGE_STREAM APP_VERSION=$TARGET_TAG --overwrite
-	oc project $SOURCE_PROJECT
+	oc label is $IMAGE_STREAM APP_VERSION=$TARGET_TAG --overwrite -n $TARGET_PROJECT --as=system:admin
 }
 
 #
@@ -45,7 +45,8 @@ function tag-to-target {
 #  $1 ImageStreamName - the name of the application to show all tags from latest
 #
 function show-tags {
-	[ $# -lt 1 ] && echo "ImageStream Name is required." && exit 1
+	[ "$1" == "-h" ] || [ "$1" == "--help" ] && tag.help && return 0
+	[ $# -lt 1 ] && echo "ERROR: <app-name> is required." && tag.help && exit 1
     local IMAGE_STREAM=$1
 	echo "Checks where 'latest' IS of $IMAGE_STREAM points to"
 	oc describe is $IMAGE_STREAM > /tmp/is.tmp
@@ -63,15 +64,11 @@ function show-tags {
 #  $2 TagName - the name of the tag 
 #
 function tag-latest {
-	[ $# -lt 2 ] && echo "ImageStream Name is required." && exit 1
+	[ "$1" == "-h" ] || [ "$1" == "--help" ] && tag.help && return 0
+	[ $# -lt 2 ] && echo "ERROR: <app-name> and <tag-name> are required arguments." && tag.help && exit 1
     local IMAGE_STREAM=$1
     local TAG_NAME=$2
-    
-    if [[ $TAG_NAME == "" ]]; then	
-    	echo "Tag is required. "
-    	exit 1
-    fi
-    
+        
     # getting current project
     local SOURCE_PROJECT=$(oc project -q)
     

--- a/plugins.d/tag.global.plugin
+++ b/plugins.d/tag.global.plugin
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+function tag.help {
+   # Select either of the two or both, depending on the functionality provided by the plugin
+   echo "  oc-cluster show-tags <ImageStreamName>"
+   echo "  oc-cluster tag-latest <ImageStreamName> <tag-name> - tags 'latest' ImageStream to <tag-name>"
+   echo "  oc-cluster tag-to-target <ImageStreamName> <source-tag> <target-project> <target-tag>"
+   echo "      Assumes that <source-tag> is something like 'RELEASE_1_1' and <target-tag> is 'latest'"
+   echo "      It first 'copies' the 'RELEASE_1_1' into <target-project> and call it 'latest'"
+   echo "      and then tags <target-project>:latest to 'RELEASE_1_1'"
+}
+
+#
+# Args:
+#  $1 ImageStreamName - the name of the application to tag
+#  $2 source-tag - the source tag to use
+#  $3 target-project - the name of the target project
+#  $4 target-tag - the name of the target tag in target-project
+#
+function tag-to-target {
+	[ $# -lt 4 ] && echo "ImageStream Name is required." && exit 1
+	local IMAGE_STREAM=$1
+	local SOURCE_TAG=$2
+	local TARGET_PROJECT=$3
+	local TARGET_TAG=$4
+	local SOURCE_PROJECT=$(oc project -q)
+	
+	if [[ $SOURCE_PROJECT == $TARGET_PROJECT ]]; then
+		echo "$SOURCE_PROJECT equals $TARGET_PROJECT. Use tag-latest instead."
+		exit 1
+	fi
+	
+	echo "Tagging '$SOURCE_TAG' image stream '$IMAGE_STREAM' from '$SOURCE_PROJECT' to target project '$TARGET_PROJECT' with tag '$TARGET_TAG'..."
+		
+	oc tag $SOURCE_PROJECT/$IMAGE_STREAM:$SOURCE_TAG $TARGET_PROJECT/$IMAGE_STREAM:$TARGET_TAG
+	oc tag $TARGET_PROJECT/$IMAGE_STREAM:$TARGET_TAG $TARGET_PROJECT/$IMAGE_STREAM:$SOURCE_TAG
+	
+	oc project $TARGET_PROJECT
+	oc label is $IMAGE_STREAM APP_VERSION=$TARGET_TAG --overwrite
+	oc project $SOURCE_PROJECT
+}
+
+#
+# Args:
+#  $1 ImageStreamName - the name of the application to show all tags from latest
+#
+function show-tags {
+	[ $# -lt 1 ] && echo "ImageStream Name is required." && exit 1
+    local IMAGE_STREAM=$1
+	echo "Checks where 'latest' IS of $IMAGE_STREAM points to"
+	oc describe is $IMAGE_STREAM > /tmp/is.tmp
+	local imageID=$(cat /tmp/is.tmp | grep \* | awk -F$'/' '{print $3}' | head -n 1)
+		
+	local tagNames=$(cat /tmp/is.tmp | grep -B 1 "tagged from $imageID" | sed '/^  tagged from/d' | sed '/^--/d')
+	for tag in $tagNames ; do
+		echo "'latest' points on $tag"
+	done
+}
+
+#
+# Args:
+#  $1 ImageStreamName - the name of the application to show all tags from latest
+#  $2 TagName - the name of the tag 
+#
+function tag-latest {
+	[ $# -lt 2 ] && echo "ImageStream Name is required." && exit 1
+    local IMAGE_STREAM=$1
+    local TAG_NAME=$2
+    
+    if [[ $TAG_NAME == "" ]]; then	
+    	echo "Tag is required. "
+    	exit 1
+    fi
+    
+    # getting current project
+    local SOURCE_PROJECT=$(oc project -q)
+    
+	# getting imagestream ID
+	# this algorythm is just taking the FIRST entry of the line starting with a '*'
+	imageID=$(oc describe is $IMAGE_STREAM | grep \* | awk -F$'/' '{print $3}' | head -n 1)
+	imageID="$SOURCE_PROJECT/"$imageID
+
+	#echo "oc tag $imageID $SOURCE_PROJECT/$IMAGE_STREAM:$TAG_NAME "
+	oc tag $imageID $SOURCE_PROJECT/$IMAGE_STREAM:$TAG_NAME
+
+}
+


### PR DESCRIPTION
3 more global commands:

oc-cluster show-tags <image-stream> - shows all tags on 'latest' image stream
oc-cluster tag-latest <image-stream> <tag> - tags 'latest' of 'image-stream' to <tag>
oc-cluster tag-to-target <image-stream> <source-tag> <target-project> <target-tag>
   Assumes that <source-tag> is something like 'RELEASE_1_1' and <target-tag> is 'latest'
   It first 'copies' the 'RELEASE_1_1' into <target-project> and call it 'latest'
   and then tags <target-project>:latest to 'RELEASE_1_1'

