### PR TITLE
remove invalid --request-timeout option

### DIFF
--- a/oc-cluster
+++ b/oc-cluster
@@ -43,7 +43,7 @@ if [[ "$__PLATFORM" == "unknown" ]]; then
 fi
 
 # Determine the version and type of client
-__VERSION=$(oc version --request-timeout=1 2> /dev/null | grep oc | awk -F'+' '{print $1}'| awk '{print $2}')
+__VERSION=$(oc version 2> /dev/null | grep oc | awk -F'+' '{print $1}'| awk '{print $2}')
 if [[ "${__VERSION}" =~ ^v3.*$  ]]; then
     __TYPE="ocp"
     __IMAGE="registry.access.redhat.com/openshift3/ose"


### PR DESCRIPTION
The `oc version --request-timeout=1` command is invalid with oc v1.3.1. See below for the error:


```
[9:15][mmckinst@mmckinst oc-cluster-wrapper] oc version --request-timeout=1 
Error: unknown flag: --request-timeout

Usage:
  oc version [options]
Use "oc options" for a list of global command-line options (applies to all commands).

[9:15][mmckinst@mmckinst oc-cluster-wrapper] 
```

And my specific version infor if necessary is:

```
[9:15][mmckinst@mmckinst oc-cluster-wrapper] oc version
oc v1.3.1
kubernetes v1.3.0+52492b4
features: Basic-Auth GSSAPI Kerberos SPNEGO
[9:15][mmckinst@mmckinst oc-cluster-wrapper] 
[9:19][mmckinst@mmckinst oc-cluster-wrapper] rpm -q origin-clients                    
origin-clients-1.3.1-1.fc25.x86_64
[9:19][mmckinst@mmckinst oc-cluster-wrapper] 

```
