### PR TITLE
oc-cluster: Fix to show deployment output in any case

### DIFF
--- a/oc-cluster
+++ b/oc-cluster
@@ -1130,7 +1130,7 @@ then
         ;;
       *)
         shift # past argument
-        $key "$@"  2> /dev/null || echo "Command $key not found"
+        $key "$@" 
         ;;
    esac
 else


### PR DESCRIPTION
I think it is better to show the original output of the executed command instead of assuming that the command was not found, e.g. 

```
--> Creating resources ...
    error: buildconfigs.build.openshift.io "build-origin" already exists
    error: buildconfigs.build.openshift.io "origin-release-builder" already exists
    error: deploymentconfigs.apps.openshift.io "build-origin" already exists
    error: imagestreams.image.openshift.io "build-origin" already exists
    error: imagestreams.image.openshift.io "origin-release" already exists
    error: imagestreams.image.openshift.io "origin-release-builder" already exists
    error: routes.route.openshift.io "build-origin" already exists
    error: services "build-origin" already exists
--> Failed
```