### PR TITLE
List profiles in reverse chronological order

### DIFF
--- a/oc-cluster
+++ b/oc-cluster
@@ -796,7 +796,7 @@ function list {
   echo "Profiles:"
   if [[ -d "$OPENSHIFT_PROFILES_DIR/" ]]
   then 
-    for i in `ls $OPENSHIFT_PROFILES_DIR`
+    for i in `ls -tr $OPENSHIFT_PROFILES_DIR`
     do
       echo "- $i"
     done


### PR DESCRIPTION
I often bring profiles up/down during the course of active development. It's helpful to see the latest profile I created at the bottom of `oc-cluster list` output, immediately available to name on the next command (typically `oc-cluster up`).